### PR TITLE
Allow move-focus-or-tab as action

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Commands:
 - `ZellijNavigateDown`
 - `ZellijNavigateUp`
 - `ZellijNavigateRight`
+- `ZellijNavigateLeftTab`
+- `ZellijNavigateDownTab`
+- `ZellijNavigateUpTab`
+- `ZellijNavigateRightTab`
 
 It also exports the `lua` versions, which you can call like this:
 
@@ -20,6 +24,10 @@ It also exports the `lua` versions, which you can call like this:
 - `require("zellij-nav").down()`
 - `require("zellij-nav").up()`
 - `require("zellij-nav").right()`
+- `require("zellij-nav").left_tab()`
+- `require("zellij-nav").down_tab()`
+- `require("zellij-nav").up_tab()`
+- `require("zellij-nav").right_tab()`
 
 This is written in the spirit of
 [vim-tmux-navigator](https://github.com/alexghergh/nvim-tmux-navigation/), but
@@ -36,10 +44,10 @@ possible.
   lazy = true,
   event = "VeryLazy",
   keys = {
-    { "<c-h>", "<cmd>ZellijNavigateLeft<cr>",  { silent = true, desc = "navigate left"  } },
+    { "<c-h>", "<cmd>ZellijNavigateLeftTab<cr>",  { silent = true, desc = "navigate left or tab"  } },
     { "<c-j>", "<cmd>ZellijNavigateDown<cr>",  { silent = true, desc = "navigate down"  } },
     { "<c-k>", "<cmd>ZellijNavigateUp<cr>",    { silent = true, desc = "navigate up"    } },
-    { "<c-l>", "<cmd>ZellijNavigateRight<cr>", { silent = true, desc = "navigate right" } },
+    { "<c-l>", "<cmd>ZellijNavigateRightTab<cr>", { silent = true, desc = "navigate right or tab" } },
   },
   opts = {},
 }
@@ -54,10 +62,10 @@ possible.
     require("zellij-nav").setup()
 
     local map = vim.keymap.set
-    map("n", "<c-h>", "<cmd>ZellijNavigateLeft<cr>",  { desc = "navigate left"  })
+    map("n", "<c-h>", "<cmd>ZellijNavigateLeftTab<cr>",  { desc = "navigate left or tab"  })
     map("n", "<c-j>", "<cmd>ZellijNavigateDown<cr>",  { desc = "navigate down"  })
     map("n", "<c-k>", "<cmd>ZellijNavigateUp<cr>",    { desc = "navigate up"    })
-    map("n", "<c-l>", "<cmd>ZellijNavigateRight<cr>", { desc = "navigate right" })
+    map("n", "<c-l>", "<cmd>ZellijNavigateRightTab<cr>", { desc = "navigate right or tab" })
 
   end
 }

--- a/lua/zellij-nav/init.lua
+++ b/lua/zellij-nav/init.lua
@@ -1,6 +1,12 @@
 local M = {}
 
-local function nav(short_direction, direction)
+local function nav(short_direction, direction, action)
+  action = action or "move-focus"
+
+  if action ~= "move-focus" and action ~= "move-focus-or-tab" then
+    error("invalid action: " .. action)
+  end
+
   -- get window ID, try switching windows, and get ID again to see if it worked
   local cur_winnr = vim.fn.winnr()
   vim.api.nvim_command("wincmd " .. short_direction)
@@ -8,27 +14,27 @@ local function nav(short_direction, direction)
 
   -- if the window ID didn't change, then we didn't switch
   if cur_winnr == new_winnr then
-    vim.fn.system("zellij action move-focus " .. direction)
+    vim.fn.system("zellij action " .. action .. " " .. direction)
     if vim.v.shell_error ~= 0 then
       error("zellij executable not found in path")
     end
   end
 end
 
-function M.up()
-  nav("k", "up")
+function M.up(action)
+  nav("k", "up", action)
 end
 
-function M.down()
-  nav("j", "down")
+function M.down(action)
+  nav("j", "down", action)
 end
 
-function M.right()
-  nav("l", "right")
+function M.right(action)
+  nav("l", "right", action)
 end
 
-function M.left()
-  nav("h", "left")
+function M.left(action)
+  nav("h", "left", action)
 end
 
 -- create our exported setup() function

--- a/lua/zellij-nav/init.lua
+++ b/lua/zellij-nav/init.lua
@@ -1,9 +1,8 @@
 local M = {}
 
 local function nav(short_direction, direction, action)
-  -- Use "move-focus" if nav is called via user command or
-  -- action is nil.
-  if type(action) == "table" or not action then
+  -- Use "move-focus" if action is nil.
+  if not action then
     action = "move-focus"
   end
 
@@ -25,20 +24,36 @@ local function nav(short_direction, direction, action)
   end
 end
 
-function M.up(action)
-  nav("k", "up", action)
+function M.up()
+  nav("k", "up", nil)
 end
 
-function M.down(action)
-  nav("j", "down", action)
+function M.down()
+  nav("j", "down", nil)
 end
 
-function M.right(action)
-  nav("l", "right", action)
+function M.right()
+  nav("l", "right", nil)
 end
 
-function M.left(action)
-  nav("h", "left", action)
+function M.left()
+  nav("h", "left", nil)
+end
+
+function M.up_tab()
+  nav("k", "up", "move-focus-or-tab")
+end
+
+function M.down_tab()
+  nav("j", "down", "move-focus-or-tab")
+end
+
+function M.right_tab()
+  nav("l", "right", "move-focus-or-tab")
+end
+
+function M.left_tab()
+  nav("h", "left", "move-focus-or-tab")
 end
 
 -- create our exported setup() function
@@ -48,6 +63,11 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("ZellijNavigateDown", M.down, {})
   vim.api.nvim_create_user_command("ZellijNavigateLeft", M.left, {})
   vim.api.nvim_create_user_command("ZellijNavigateRight", M.right, {})
+
+  vim.api.nvim_create_user_command("ZellijNavigateUpTab", M.up_tab, {})
+  vim.api.nvim_create_user_command("ZellijNavigateDownTab", M.down_tab, {})
+  vim.api.nvim_create_user_command("ZellijNavigateLeftTab", M.left_tab, {})
+  vim.api.nvim_create_user_command("ZellijNavigateRightTab", M.right_tab, {})
 end
 
 return M

--- a/lua/zellij-nav/init.lua
+++ b/lua/zellij-nav/init.lua
@@ -1,7 +1,11 @@
 local M = {}
 
 local function nav(short_direction, direction, action)
-  action = action or "move-focus"
+  -- Use "move-focus" if nav is called via user command or
+  -- action is nil.
+  if type(action) == "table" or not action then
+    action = "move-focus"
+  end
 
   if action ~= "move-focus" and action ~= "move-focus-or-tab" then
     error("invalid action: " .. action)


### PR DESCRIPTION
Hi, thank you for the plugin. Would you accept a small improvement to allow `move-focus-or-tab` as another action option?

My use-case is I want to be able to move to another tab within Neovim with the following configuration:

```lua
    keys = {
        {
            "<c-h>",
            function() require("zellij-nav").left("move-focus-or-tab") end,
            { silent = true, desc = "navigate left" },
        },
        { "<c-j>", "<cmd>ZellijNavigateDown<cr>", { silent = true, desc = "navigate down" } },
        { "<c-k>", "<cmd>ZellijNavigateUp<cr>", { silent = true, desc = "navigate up" } },
        {
            "<c-l>",
            function() require("zellij-nav").right("move-focus-or-tab") end,
            { silent = true, desc = "navigate right" },
        },
    },
```