### PR TITLE
Fix calling Zellij when not inside. Added on_leave function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ It also exports the `lua` versions, which you can call like this:
 - `require("zellij-nav").up_tab()`
 - `require("zellij-nav").right_tab()`
 
+If you want to call a function when leaving neovim to another pane or tab in zellij, you can use the on_leave config:
+
+```lua
+require("zellij-nav").setup({
+    config.on_leave = function()
+        -- Your function to call here
+    end,
+})
+```
+
 This is written in the spirit of
 [vim-tmux-navigator](https://github.com/alexghergh/nvim-tmux-navigation/), but
 for zellij instead, while also aiming to be as simple and lightweight as
@@ -49,7 +59,9 @@ possible.
     { "<c-k>", "<cmd>ZellijNavigateUp<cr>",    { silent = true, desc = "navigate up"    } },
     { "<c-l>", "<cmd>ZellijNavigateRightTab<cr>", { silent = true, desc = "navigate right or tab" } },
   },
-  opts = {},
+  opts = {
+        config.on_leave = function() end, -- Function to call when leaving neovim to another pane/tab
+    },
 }
 ```
 
@@ -59,7 +71,9 @@ possible.
 {
   "https://github.com/swaits/zellij-nav.nvim",
   config = function()
-    require("zellij-nav").setup()
+    require("zellij-nav").setup({
+            config.on_leave = function() end, -- Function to call when leaving neovim to another pane/tab
+        })
 
     local map = vim.keymap.set
     map("n", "<c-h>", "<cmd>ZellijNavigateLeftTab<cr>",  { desc = "navigate left or tab"  })
@@ -75,7 +89,9 @@ possible.
 
 ```vim
 Plug 'https://github.com/swaits/zellij-nav.nvim'
-lua require("zellij-nav").setup()
+lua require("zellij-nav").setup({
+            config.on_leave = function() end, -- Function to call when leaving neovim to another pane/tab
+        })
 
 nnoremap <c-h> <cmd>ZellijNavigateLeft<cr>
 nnoremap <c-j> <cmd>ZellijNavigateDown<cr>
@@ -88,8 +104,9 @@ nnoremap <c-l> <cmd>ZellijNavigateRight<cr>
 This plugin only covers the Neovim side of things. To achieve a fully seamless
 workflow, we also need zellij to perform a few tasks.
 
-When an instance of neovim is active, change zellij into lock mode using [zellij-autoloc](https://github.com/fresh2dev/zellij-autolock). 
+When an instance of neovim is active, change zellij into lock mode using [zellij-autoloc](https://github.com/fresh2dev/zellij-autolock).
 an example section of the config could be
+
 ```
 ...
           autolock location="https://github.com/fresh2dev/zellij-autolock/releases/latest/download/zellij-autolock.wasm" {
@@ -99,7 +116,9 @@ an example section of the config could be
           }
 ...
 ```
+
 And to achieve unlocking when neovim is unfocused, you can add the following to your neovim config:
+
 ```lua
 -- NOTE: Ensures that when exiting NeoVim, Zellij returns to normal mode
 vim.api.nvim_create_autocmd("VimLeave", {

--- a/lua/zellij-nav/init.lua
+++ b/lua/zellij-nav/init.lua
@@ -17,9 +17,11 @@ local function nav(short_direction, direction, action)
 
   -- if the window ID didn't change, then we didn't switch
   if cur_winnr == new_winnr then
-    vim.fn.system("zellij action " .. action .. " " .. direction)
-    if vim.v.shell_error ~= 0 then
-      error("zellij executable not found in path")
+    if vim.env.ZELLIJ ~= nil then -- if the zellij env does not exit, stop.
+      vim.fn.system("zellij action " .. action .. " " .. direction)
+      if vim.v.shell_error ~= 0 then
+        error("zellij executable not found in path")
+      end
     end
   end
 end

--- a/lua/zellij-nav/init.lua
+++ b/lua/zellij-nav/init.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local config = {
+  on_leave = function() end,
+}
+
 local function nav(short_direction, direction, action)
   -- Use "move-focus" if action is nil.
   if not action then
@@ -19,6 +23,7 @@ local function nav(short_direction, direction, action)
   if cur_winnr == new_winnr then
     if vim.env.ZELLIJ ~= nil then -- if the zellij env does not exit, stop.
       vim.fn.system("zellij action " .. action .. " " .. direction)
+      config.on_leave()
       if vim.v.shell_error ~= 0 then
         error("zellij executable not found in path")
       end
@@ -60,6 +65,7 @@ end
 
 -- create our exported setup() function
 function M.setup(opts)
+  config = vim.tbl_deep_extend("force", config, opts.config or {})
   -- create our commands
   vim.api.nvim_create_user_command("ZellijNavigateUp", M.up, {})
   vim.api.nvim_create_user_command("ZellijNavigateDown", M.down, {})


### PR DESCRIPTION
This fixes 1 issue with the plugin when using Neovim outside of Zellij and using the plugin to navigate around. When trying to move to another pane or tab, the plugin calls an error. This will now just cancel instead of calling an error when not inside of Zellij. This fixes issue #12

I also added a function of `on_leave` to call each time Zellij is called to move to another pane/tab. This is especially useful if you want to call a vim function to lock/unlock Zillij or something else along the lines when exiting Neovim using the keybinds of zellij-nav.nvim.

To setup `on_leave` Just do:
```lua
require("zellij-nav").setup({
  config.on_leave = function() ... end,
})
```